### PR TITLE
overwrite get_initial_state, otherwise it won't work properly

### DIFF
--- a/keras_ordered_neurons/layers.py
+++ b/keras_ordered_neurons/layers.py
@@ -2,6 +2,10 @@ import warnings
 
 from .backend import layers, activations, initializers, regularizers, constraints
 from .backend import backend as K
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import state_ops
+from tensorflow.python.util import nest
 
 from .activations import cumax
 
@@ -17,6 +21,27 @@ def _generate_dropout_mask(ones, rate, training=None, count=1):
         ones,
         training=training) for _ in range(count)]
 
+def _generate_zero_filled_state_for_cell(cell, inputs, batch_size, dtype):
+    if inputs is not None:
+        batch_size = array_ops.shape(inputs)[0]
+        dtype = inputs.dtype
+    return _generate_zero_filled_state(batch_size, cell.state_size, dtype)
+
+def _generate_zero_filled_state(batch_size_tensor, state_size, dtype):
+    """Generate a zero filled tensor with shape [batch_size, state_size]."""
+    if batch_size_tensor is None or dtype is None:
+        raise ValueError(
+            'batch_size and dtype cannot be None while constructing initial state: '
+            'batch_size={}, dtype={}'.format(batch_size_tensor, dtype))
+    def create_zeros(unnested_state_size):
+        flat_dims = tensor_shape.as_shape(unnested_state_size).as_list()
+        init_state_size = [batch_size_tensor] + flat_dims
+        return array_ops.zeros(init_state_size, dtype=dtype)
+
+    if nest.is_sequence(state_size):
+        return nest.map_structure(create_zeros, state_size)
+    else:
+        return create_zeros(state_size)
 
 class ONLSTMCell(layers.Layer):
     """Cell class for the ON-LSTM layer.
@@ -296,7 +321,10 @@ class ONLSTMCell(layers.Layer):
         base_config = super(ONLSTMCell, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
-
+     def get_initial_state(self, inputs=None, batch_size=None, dtype=None):
+        return list(_generate_zero_filled_state_for_cell(
+            self, inputs, batch_size, dtype))
+    
 class ONLSTM(layers.RNN):
     """Ordered Neurons LSTM
 


### PR DESCRIPTION
To my best of knowledge (and the result of my nlp experiment supports the point), LSTM resets its state to be initial state before processing new data, so the "get_initial_state" should be overwriten.